### PR TITLE
nodeFinderのオブジェクト指向っぽい実装アプローチ

### DIFF
--- a/dev/ram_api_rewrite/src/testApp.cpp
+++ b/dev/ram_api_rewrite/src/testApp.cpp
@@ -31,13 +31,15 @@ void testApp::update()
 void testApp::draw()
 {
     ofEnableSmoothing();
+	
+	ramNodeFinder nf("Ando_2012-09-01_19-19-45", ramActor::JOINT_ADBOMEN);
+	cout << nf.getPtr().size() << endl;
     
     cam.begin();
 
-
     // nodeFinder example 1
     {
-        vector<ramNode> nodes = nodeFinder.findNode(ramActor::JOINT_ADBOMEN);
+        vector<ramNode> nodes = nodeFinder.findNodes(ramActor::JOINT_ADBOMEN);
         for (int i=0; i<nodes.size(); i++)
         {
             ramNode &node = nodes.at(i);
@@ -63,7 +65,7 @@ void testApp::draw()
     
     // nodeFinder example 2
     {
-        ramNode &node = nodeFinder.findNode(myActorName, ramActor::JOINT_HEAD);
+        ramNode node = nodeFinder.findNode(myActorName, ramActor::JOINT_HEAD);
         
         glPushAttrib(GL_ALL_ATTRIB_BITS);
         glPushMatrix();

--- a/libs/ram/ramActorManager.h
+++ b/libs/ram/ramActorManager.h
@@ -13,7 +13,7 @@ class ramActorManager
 public:
 
 	// singleton
-	static ramActorManager& instance()
+	inline static ramActorManager& instance()
     {
         if (_instance == NULL)
             _instance = new ramActorManager;

--- a/libs/ram/ramNodeFinder.h
+++ b/libs/ram/ramNodeFinder.h
@@ -1,53 +1,109 @@
-//
-//  nodeFinder.h
-//  RAMDanceToolkit
-//
-//  Created by motoishmz on 2012/11/06.
-//  Copyright (c) 2012年 YCAMInterlab. All rights reserved.
-//
-
-#ifndef RAMDanceToolkit_nodeFinder_h
-#define RAMDanceToolkit_nodeFinder_h
+#pragma once
 
 #include "ramActorManager.h"
 #include "ramActor.h"
-
 
 class ramNodeFinder
 {
   
 public:
     
-    ramNodeFinder(){}
-    ~ramNodeFinder(){}
+    ramNodeFinder() : actor_name(""), joint_id(-1) {}
+	ramNodeFinder(int joint_id) : actor_name(""), joint_id(joint_id) {}
+	ramNodeFinder(const string& actor_name) : actor_name(actor_name), joint_id(-1) {}
+	ramNodeFinder(const string& actor_name, int joint_id) : actor_name(actor_name), joint_id(joint_id) {}
     
-    vector<ramNode> findNode(int jointId)
+	void setActorName(string actor_name_) { actor_name = actor_name_; }
+	void setJointID(int joint_id_) { joint_id = joint_id_; }
+	
+	vector<ramNode> get()
+	{
+		vector<ramNode> nodes;
+		
+		bool has_target_actor = !actor_name.empty();
+		bool has_target_node = joint_id != -1;
+		
+		for (int i = 0; i < getActorManager().getNumActor(); i++)
+        {
+			ramActor &actor = getActorManager().getActor(i);
+
+			if (has_target_actor && actor_name != actor.getName()) continue;
+			
+			for (int n = 0; n < actor.getNumNode(); n++)
+			{
+				if (has_target_node && joint_id != n) continue;
+				
+				ramNode &node = actor.getNode(n);
+				nodes.push_back(node);
+			}
+        }
+
+		return nodes;
+	}
+	
+	vector<ramNode*> getPtr()
+	{
+		vector<ramNode*> nodes;
+		
+		bool has_target_actor = !actor_name.empty();
+		bool has_target_node = joint_id != -1;
+		
+		for (int i = 0; i < getActorManager().getNumActor(); i++)
+        {
+			ramActor &actor = getActorManager().getActor(i);
+			
+			if (has_target_actor && actor_name != actor.getName()) continue;
+			
+			for (int n = 0; n < actor.getNumNode(); n++)
+			{
+				if (has_target_node && joint_id != n) continue;
+				
+				ramNode &node = actor.getNode(n);
+				nodes.push_back(&node);
+			}
+        }
+		
+		return nodes;
+	}
+
+	
+    static vector<ramNode> findNodes(int jointId)
     {
         vector<ramNode> nodes;
+		
         for (int i=0; i<getActorManager().getNumActor(); i++)
         {
             ramNode &node = getActorManager().getActor(i).getNode(jointId);
-            
-            cout << node.getPosition() << endl;
-            
             nodes.push_back(node);
-            
-            cout << nodes.at(i).getPosition() << endl;
-            cout << "--" << endl;
         }
-        cout << "--------" << endl;
+		
+        return nodes;
+    }
+	
+	static vector<ramNode> findNodes(const string& actoreName)
+    {
+        vector<ramNode> nodes;
+		ramActor &actor = getActorManager().getActor(actoreName);
+		
+        for (int i=0; i<actor.getNumNode(); i++)
+        {
+            ramNode &node = actor.getNode(i);
+            nodes.push_back(node);
+        }
+		
         return nodes;
     }
     
-    ramNode& findNode(const string actoreName, int jointId)
+    static ramNode findNode(const string& actoreName, int jointId)
     {
         return getActorManager().getActor(actoreName).getNode(jointId);
     }
     
 private:
+	
+	string actor_name;
+	int joint_id;
     
-    inline ramActorManager& getActorManager() { return ramActorManager::instance(); }
+    inline static ramActorManager& getActorManager() { return ramActorManager::instance(); }
 };
 
-
-#endif


### PR DESCRIPTION
nodeFinder、オブジェクト指向っぽいアプローチもありかなと思いました。

```
ramNodeFinder nf("Ando_2012-09-01_19-19-45", ramActor::JOINT_ADBOMEN);

void testApp::draw()
{
    vector<ramNode> nodes = nf.get();
    // ...

    vector<ramNode*> nodePtrs = nf.getPtr();
    // ...
}
```

みたいな感じで?

vector<ramNode> だと毎フレームでコピーがだいぶ発生してしまうので vector<ramNode*> の方が効率は確実にいいのとポインタでしかできない事も出てくるとおもうんですが、そのあたりの線引き、ちょっと難しいっすね…。。。
